### PR TITLE
SSE-2 Let channels run indefinitely with a heartbeat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,15 @@
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.4</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/clueride/sse/GameStateEventFactory.java
+++ b/src/main/java/com/clueride/sse/GameStateEventFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/9/18.
+ */
+package com.clueride.sse;
+
+import org.glassfish.jersey.media.sse.OutboundEvent;
+
+/**
+ * Constructs the different events produced for the Game State.
+ *
+ * The following events are constructed:
+ * <UL>
+ *     <li>Game State message updating subscribers to game state changes.</li>
+ *     <li>Closing message to alert subscribers the channel is closing down.</li>
+ *     <li>Keep-alive message sent when no message has been broadcast for 30 seconds.</li>
+ * </UL>
+ */
+public class GameStateEventFactory {
+    static Integer messageId = 101;
+
+    public OutboundEvent getGameStateEvent(String payload) {
+        return bundleMessage(payload);
+    }
+
+    public OutboundEvent getClosingMessage() {
+        return bundleMessage("Closing channel");
+    }
+
+    public OutboundEvent getKeepAliveEvent() {
+        return bundleMessage(null);
+    }
+
+    private OutboundEvent bundleMessage(String message) {
+        final OutboundEvent.Builder eventBuilder = new OutboundEvent.Builder();
+        eventBuilder.name("message");
+        eventBuilder.id("" + generateMessageId());
+        if (message == null) {
+            eventBuilder.comment("Keep Alive");
+        } else {
+            eventBuilder.data(message);
+        }
+        return eventBuilder.build();
+    }
+
+    private Integer generateMessageId() {
+        return messageId++;
+    }
+
+}

--- a/src/main/java/com/clueride/sse/GameStateService.java
+++ b/src/main/java/com/clueride/sse/GameStateService.java
@@ -36,4 +36,12 @@ public interface GameStateService {
      * @param outingId Unique identifier for the associated Outing.
      */
     void releaseChannelResources(Integer outingId);
+
+    /**
+     * Sends the message to the matching outingId's channel.
+     * @param outingId Unique identifier for the Outing.
+     * @param message String to be sent to all subscribers of this Outing.
+     */
+    void broadcastMessage(Integer outingId, String message);
+
 }

--- a/src/main/java/com/clueride/sse/GameStateServiceImpl.java
+++ b/src/main/java/com/clueride/sse/GameStateServiceImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/6/18.
+ */
+package com.clueride.sse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.glassfish.jersey.media.sse.SseBroadcaster;
+
+/**
+ * Implementation of GameStateService.
+ */
+public class GameStateServiceImpl implements GameStateService {
+    private Map<Integer,ServerSentEventChannel> channelMap = new HashMap<>();
+    private final GameStateEventFactory gameStateEventFactory = new GameStateEventFactory();
+
+    @Override
+    public ServerSentEventChannel openChannelResources(Integer outingId) {
+        ServerSentEventChannel channel = getEventChannel(outingId);
+        return channel;
+    }
+
+    @Override
+    public void releaseChannelResources(Integer outingId) {
+        ServerSentEventChannel channel = getEventChannel(outingId);
+        SseBroadcaster broadcaster = channel.getBroadcaster();
+        broadcaster.broadcast(gameStateEventFactory.getClosingMessage());
+        channel.getKeepAliveGenerator().release();
+    }
+
+    @Override
+    public void broadcastMessage(Integer outingId, String message) {
+        ServerSentEventChannel channel = getEventChannel(outingId);
+        SseBroadcaster broadcaster = channel.getBroadcaster();
+        broadcaster.broadcast(gameStateEventFactory.getGameStateEvent(message));
+        KeepAliveGenerator keepAliveGenerator = channel.getKeepAliveGenerator();
+        keepAliveGenerator.reset();
+    }
+
+    ServerSentEventChannel getEventChannel(Integer outingId) {
+        ServerSentEventChannel channel;
+        if (channelMap.containsKey(outingId)) {
+            channel = channelMap.get(outingId);
+        } else {
+            channel = new ServerSentEventChannel(outingId);
+            channelMap.put(outingId, channel);
+        }
+        return channel;
+    }
+
+}

--- a/src/main/java/com/clueride/sse/GameStateWebService.java
+++ b/src/main/java/com/clueride/sse/GameStateWebService.java
@@ -4,23 +4,23 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
+   @PathParam("outingId") Integer outingId
+    ) {
+        gameStateService.releaseChannelResources(outingId);
+        return outingId;
+    }
+*
+        * http://www.apache.org/licenses/LICENSE-2.0
+            *
+            * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Created by jett on 2/25/18.
- */
-package com.clueride.sse;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+            *
+            * Created by jett on 2/25/18.
+            */
+            package com.clueride.sse;
 
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
@@ -34,119 +34,60 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.sse.EventOutput;
-import org.glassfish.jersey.media.sse.OutboundEvent;
 import org.glassfish.jersey.media.sse.SseBroadcaster;
 import org.glassfish.jersey.media.sse.SseFeature;
 
-/**
- * Broadcasts posted Game State changes to each of the clients who have subscribed to the events for a given Outing ID.
- */
-@Singleton
-@Path("game-state-broadcast")
-public class GameStateWebService {
-    private static final Logger LOGGER = Logger.getLogger(GameStateWebService.class);
+    /**
+     * Broadcasts posted Game State changes to each of the clients who have subscribed to the events for a given Outing ID.
+     */
+    @Singleton
+    @Path("game-state-broadcast")
+    public class GameStateWebService {
+        private static final Logger LOGGER = Logger.getLogger(GameStateWebService.class);
 
-    private Map<Integer,SseBroadcaster> broadcasterMap = new HashMap<>();
-    private Map<Integer,ServerSentEventChannel> channelMap = new HashMap<>();
+        private GameStateService gameStateService = new GameStateServiceImpl();
 
-    @GET
-    @Produces(SseFeature.SERVER_SENT_EVENTS)
-    @Path("{outingId}")
-    public EventOutput subscribeToOutingIdChannel(
-            @PathParam("outingId") Integer outingId,
-            @QueryParam("r") final String requestId
-    ) {
-        LOGGER.debug("Outing ID: " + outingId + "  Request ID: " + requestId);
-        ServerSentEventChannel channel = getEventChannel(outingId);
-        return channel.getEventOutput();
-    }
+        @GET
+        @Produces(SseFeature.SERVER_SENT_EVENTS)
+        @Path("{outingId}")
+        public EventOutput subscribeToOutingIdChannel(
+                @PathParam("outingId") Integer outingId,
+                @QueryParam("r") final String requestId
+        ) {
+            LOGGER.debug("Outing ID: " + outingId + "  Request ID: " + requestId);
+            ServerSentEventChannel channel = gameStateService.openChannelResources(outingId);
+            SseBroadcaster broadcaster = channel.getBroadcaster();
+            EventOutput eventOutput = new EventOutput();
+            broadcaster.add(eventOutput);
+            return eventOutput;
+        }
 
-    private void eventGenerator(final Integer outingId) {
-        final EventOutput eventOutput = getEventChannel(outingId).getEventOutput();
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                for (int i = 0; i < 100; i++) {
-                    try {
-                        LOGGER.info("About to write message");
-                        final OutboundEvent.Builder eventBuilder = new OutboundEvent.Builder();
-                        eventBuilder.id("" + i);
-                        eventBuilder.name("message");
-                        eventBuilder.data(String.class, "Hello world " + i + "!");
-                        final OutboundEvent event = eventBuilder.build();
-                        eventOutput.write(event);
-                        LOGGER.info("Message sent: " + event.toString());
-                    } catch (IOException e) {
-                        throw new RuntimeException("Error when writing the event.", e);
-                    } catch (NullPointerException npe) {
-                        LOGGER.warn("Event Not sent against " + outingId, npe);
-                    }
+        @POST
+        @Path("{outingId}")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.TEXT_PLAIN)
+        public String broadcastMessage(
+                String message,
+                @PathParam("outingId") Integer outingId
+        ) {
+            gameStateService.broadcastMessage(outingId, message);
+            return "Message '" + message + "' has been broadcast.";
+        }
 
-                    try {
-                        TimeUnit.SECONDS.sleep(30);
-                    } catch (InterruptedException e) {
-                        // Eat exception
-                    }
-                }
-            }
-        }).start();
-    }
-
+    /**
+     * Releases channel and its resources after notifying subscribers.
+     * @param outingId Unique identifier for the channel.
+     * @return the ID of the channel that has been closed.
+     */
     @POST
-    @Path("{outingId}")
+    @Path("close/{outingId}")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.TEXT_PLAIN)
-    public String broadcastMessage(
-            String message,
+    public Integer closeChannel(
             @PathParam("outingId") Integer outingId
     ) {
-        OutboundEvent.Builder eventBuilder = new OutboundEvent.Builder();
-        OutboundEvent event = eventBuilder.name("message")
-                .mediaType(MediaType.TEXT_PLAIN_TYPE)
-                .data(String.class, message)
-                .build();
-
-        SseBroadcaster broadcaster = getSseBroadcaster(outingId);
-        broadcaster.broadcast(event);
-        return "Message '" + message + "' has been broadcast.";
+        gameStateService.releaseChannelResources(outingId);
+        return outingId;
     }
-
-    SseBroadcaster getSseBroadcaster(Integer outingId) {
-        SseBroadcaster broadcaster;
-        if (broadcasterMap.containsKey(outingId)) {
-            broadcaster = broadcasterMap.get(outingId);
-        } else {
-            broadcaster = new SseBroadcaster();
-            broadcasterMap.put(outingId, broadcaster);
-        }
-        return broadcaster;
-    }
-
-    ServerSentEventChannel getEventChannel(Integer outingId) {
-        ServerSentEventChannel channel;
-        if (channelMap.containsKey(outingId)) {
-            channel = channelMap.get(outingId);
-        } else {
-            channel = new ServerSentEventChannel(outingId);
-            channelMap.put(outingId, channel);
-            eventGenerator(outingId);
-        }
-        return channel;
-    }
-
-//    @GET
-//    @Path("{outingId}")
-//    @Produces(SseFeature.SERVER_SENT_EVENTS)
-//    public EventOutput listenToBroadcast(
-//            @PathParam("outingId") Integer outingId,
-//            @QueryParam("lastEventId") String lastEventId,
-//            @QueryParam("r") String unsure
-//    ) {
-//        final EventOutput eventOutput = new EventOutput();
-//        LOGGER.info("R: " + unsure);
-//        SseBroadcaster broadcaster = getSseBroadcaster(outingId);
-//        broadcaster.add(eventOutput);
-//        return eventOutput;
-//    }
 
 }

--- a/src/main/java/com/clueride/sse/KeepAliveGenerator.java
+++ b/src/main/java/com/clueride/sse/KeepAliveGenerator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/10/18.
+ */
+package com.clueride.sse;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Generates Keep Alive events whenever no other message has been sent
+ * for a certain period of time.
+ */
+public class KeepAliveGenerator {
+    public static Integer MAX_INACTIVE_PERIOD_SECONDS = 30;
+
+    private final Thread thread;
+    private Runnable action;
+    private State state;
+
+    /**
+     * Constructor using the standard max inactive period.
+     */
+    public KeepAliveGenerator() {
+       this(MAX_INACTIVE_PERIOD_SECONDS);
+    }
+
+    /**
+     * Constructor accepting a non-standard max inactive period.
+     */
+    public KeepAliveGenerator(final Integer maxInactivePeriodInSeconds) {
+        state = State.INITIALIZING;
+
+        thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                state = State.RUNNING;
+                while (state == State.RUNNING) {
+                    try {
+                        TimeUnit.SECONDS.sleep(maxInactivePeriodInSeconds);
+                        action.run();
+                    } catch (InterruptedException e) {
+                        switch (state) {
+                            case RUNNING:
+                                break;
+                            case RESET_REQUESTED:
+                                state = State.RUNNING;
+                                break;
+                            case RELEASE_REQUESTED:
+                                break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Provide the thread with the action to be invoked upon the timer firing.
+     * @param action Runnable to be executed upon firing.
+     */
+    public void setAction(Runnable action) {
+        this.action = action;
+    }
+
+    /**
+     * Begins running the timer loop.
+     */
+    public void start() {
+        state = State.RUNNING;
+        thread.start();
+    }
+
+    /**
+     * Resets the counter so another 30 seconds will have to elapse before the action is run.
+     */
+    public void reset() {
+        state = State.RESET_REQUESTED;
+        thread.interrupt();
+    }
+
+    /**
+     * Shuts down the loop and closes the thread.
+     */
+    public void release() {
+        state = State.RELEASE_REQUESTED;
+        thread.interrupt();
+    }
+
+    public State getState() {
+        return this.state;
+    }
+
+    /**
+     * When coming out of the sleep, the state is checked against these values and the logic is steered on the state.
+     */
+    public enum State {
+        INITIALIZING,
+        RUNNING,
+        RESET_REQUESTED,
+        RELEASE_REQUESTED
+    }
+
+}

--- a/src/test/java/com/clueride/sse/KeepAliveGeneratorTest.java
+++ b/src/test/java/com/clueride/sse/KeepAliveGeneratorTest.java
@@ -1,0 +1,82 @@
+package com.clueride.sse;
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/10/18.
+ */
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Exercises the KeepAliveGeneratorTest class.
+ */
+public class KeepAliveGeneratorTest {
+    private KeepAliveGenerator toTest;
+    private boolean hasRunAction = false;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        toTest = new KeepAliveGenerator(1);
+        toTest.setAction( new Runnable() {
+            @Override
+            public void run() {
+                hasRunAction = true;
+            }
+        });
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        toTest.release();
+    }
+
+    @Test
+    public void testStart() throws Exception {
+        toTest.start();
+        assertTrue(toTest.getState() == KeepAliveGenerator.State.RUNNING, "Expected to be running");
+        TimeUnit.SECONDS.sleep(2);
+        assertTrue(hasRunAction, "Expected Action to have been run");
+    }
+
+    @Test
+    public void testRelease() throws Exception {
+        toTest.start();
+        sendMessagesFasterThanTimeout();
+        toTest.release();
+        TimeUnit.SECONDS.sleep(2);
+        assertFalse(hasRunAction, "Expected Action to never have been run");
+    }
+
+    @Test
+    public void testReset() throws Exception {
+        toTest.start();
+        sendMessagesFasterThanTimeout();
+        assertFalse(hasRunAction, "Expected Action to never have been run");
+    }
+
+    private void sendMessagesFasterThanTimeout() throws InterruptedException {
+        for (int i=0; i<10; i++) {
+            TimeUnit.MILLISECONDS.sleep(750);
+            toTest.reset();
+        }
+    }
+
+}


### PR DESCRIPTION
* Adds separate "Keep Alive" generator in place of Thread with unit test.
* Factory for the various Events to be generated.
* Fleshing out the service for Game State.
* Switches over to Broadcaster instead of a single EventOutput; each
subscriber gets their own EventOutput which the Broadcaster tracks.