### PR TITLE
SSE-5 Provide Heartbeat signal out of SSE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,19 @@
             <version>2.1</version>
         </dependency>
 
-        <!-- uncomment this to get JSON support:
-         <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-binding</artifactId>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.16</version>
         </dependency>
-        -->
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -58,13 +65,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-        </dependency>
-
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/src/main/java/com/clueride/sse/CORSFilter.java
+++ b/src/main/java/com/clueride/sse/CORSFilter.java
@@ -18,20 +18,26 @@
 package com.clueride.sse;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
+
+import org.apache.log4j.Logger;
 
 /**
  * Handles the CORS responses for the Jersey requests.
  */
 @Provider
 public class CORSFilter implements ContainerResponseFilter {
+    private static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void filter(ContainerRequestContext request,
                        ContainerResponseContext response) throws IOException {
+        LOGGER.debug("Adding Headers");
         response.getHeaders().add("Access-Control-Allow-Origin", "*");
         response.getHeaders().add("Access-Control-Allow-Headers",
                 "origin, content-type, accept, authorization");

--- a/src/main/java/com/clueride/sse/Main.java
+++ b/src/main/java/com/clueride/sse/Main.java
@@ -21,8 +21,12 @@ public class Main {
      */
     static HttpServer startServer() {
         // create a resource config that scans for JAX-RS resources and providers
-        // in com.clueride package
-        final ResourceConfig rc = new ResourceConfig().packages("com.clueride");
+        // in the listed packages
+        final ResourceConfig rc = new ResourceConfig().packages(
+                "com.clueride",
+                "com.clueride.game",
+                "com.clueride.heartbeat"
+        );
 
         // create and start a new instance of grizzly http server
         // exposing the Jersey application at BASE_URI
@@ -31,8 +35,8 @@ public class Main {
 
     /**
      * Main method.
-     * @param args
-     * @throws IOException
+     * @param args array of strings passed on command line.
+     * @throws IOException if there's a problem reading console.
      */
     public static void main(String[] args) throws IOException {
         final HttpServer server = startServer();

--- a/src/main/java/com/clueride/sse/common/EventBundler.java
+++ b/src/main/java/com/clueride/sse/common/EventBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Jett Marks
+ * Copyright 2019 Jett Marks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,39 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 3/9/18.
+ * Created by jett on 2/24/19.
  */
-package com.clueride.sse;
+package com.clueride.sse.common;
 
 import org.glassfish.jersey.media.sse.OutboundEvent;
 
 /**
- * Constructs the different events produced for the Game State.
- *
- * The following events are constructed:
- * <UL>
- *     <li>Game State message updating subscribers to game state changes.</li>
- *     <li>Closing message to alert subscribers the channel is closing down.</li>
- *     <li>Keep-alive message sent when no message has been broadcast for 30 seconds.</li>
- * </UL>
+ * Common method for bundling up an event.
  */
-public class GameStateEventFactory {
-    static Integer messageId = 101;
+public class EventBundler {
 
-    public OutboundEvent getGameStateEvent(String payload) {
-        return bundleMessage(payload);
-    }
+    private static int messageId = 101;
 
-    public OutboundEvent getClosingMessage() {
-        return bundleMessage("Closing channel");
-    }
-
-    public OutboundEvent getKeepAliveEvent() {
-        return bundleMessage(null);
-    }
-
-    private OutboundEvent bundleMessage(String message) {
+    public OutboundEvent bundleMessage(String message) {
         final OutboundEvent.Builder eventBuilder = new OutboundEvent.Builder();
+        /* Apparently, this has to be the string "message". */
         eventBuilder.name("message");
         eventBuilder.id("" + generateMessageId());
         if (message == null) {

--- a/src/main/java/com/clueride/sse/common/EventFactory.java
+++ b/src/main/java/com/clueride/sse/common/EventFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.common;
+
+import org.glassfish.jersey.media.sse.OutboundEvent;
+
+/**
+ * Abstraction of the generation of Keep Alive Events.
+ */
+public interface EventFactory {
+
+    /**
+     * Produce an event that keeps the connection open.
+     *
+     * Generally, the event will be uniquely identified, but
+     * there's no content other than its identity.
+     */
+    OutboundEvent getKeepAliveEvent();
+
+}

--- a/src/main/java/com/clueride/sse/common/KeepAliveEventFactory.java
+++ b/src/main/java/com/clueride/sse/common/KeepAliveEventFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.common;
+
+import org.glassfish.jersey.media.sse.OutboundEvent;
+
+/**
+ * Implementation of EventFactory that can produce just the Keep Alive event.
+ */
+public class KeepAliveEventFactory implements EventFactory {
+    EventBundler eventBundler = new EventBundler();
+
+    @Override
+    public OutboundEvent getKeepAliveEvent() {
+        return eventBundler.bundleMessage(null);
+    }
+
+}

--- a/src/main/java/com/clueride/sse/common/KeepAliveGenerator.java
+++ b/src/main/java/com/clueride/sse/common/KeepAliveGenerator.java
@@ -15,7 +15,7 @@
  *
  * Created by jett on 3/10/18.
  */
-package com.clueride.sse;
+package com.clueride.sse.common;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/clueride/sse/common/ServerSentEventChannel.java
+++ b/src/main/java/com/clueride/sse/common/ServerSentEventChannel.java
@@ -15,7 +15,7 @@
  *
  * Created by jett on 2/26/18.
  */
-package com.clueride.sse;
+package com.clueride.sse.common;
 
 import org.glassfish.jersey.media.sse.SseBroadcaster;
 
@@ -31,17 +31,21 @@ public class ServerSentEventChannel {
     private final SseBroadcaster broadcaster = new SseBroadcaster();
     private final Integer outingId;
     private final KeepAliveGenerator keepAliveGenerator;
-    private final GameStateEventFactory gameStateEventFactory = new GameStateEventFactory();
+    private final static EventFactory keepAliveEventFactory = new KeepAliveEventFactory();
+    /* This is chosen to be a bit under the 45-second interval that the client uses for checking up on us. */
+    private final static int KEEP_ALIVE_INTERVAL = 35;
 
-    public ServerSentEventChannel(Integer outingId) {
+    public ServerSentEventChannel(
+            Integer outingId
+    ) {
         this.outingId = outingId;
-        keepAliveGenerator = new KeepAliveGenerator();
+        keepAliveGenerator = new KeepAliveGenerator(KEEP_ALIVE_INTERVAL);
         keepAliveGenerator.setAction(
                 new Runnable() {
                     @Override
                     public void run() {
                         broadcaster.broadcast(
-                                gameStateEventFactory.getKeepAliveEvent()
+                                keepAliveEventFactory.getKeepAliveEvent()
                         );
                     }
                 }

--- a/src/main/java/com/clueride/sse/game/GameStateEventFactory.java
+++ b/src/main/java/com/clueride/sse/game/GameStateEventFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/9/18.
+ */
+package com.clueride.sse.game;
+
+import org.glassfish.jersey.media.sse.OutboundEvent;
+
+import com.clueride.sse.common.EventBundler;
+
+/**
+ * Constructs the different events produced for the Game State.
+ *
+ * The following events are constructed:
+ * <UL>
+ *     <li>Game State message updating subscribers to game state changes.</li>
+ *     <li>Closing message to alert subscribers the channel is closing down.</li>
+ * </UL>
+ */
+public class GameStateEventFactory {
+    EventBundler eventBundler = new EventBundler();
+
+    public OutboundEvent getGameStateEvent(String payload) {
+        return eventBundler.bundleMessage(payload);
+    }
+
+    public OutboundEvent getClosingMessage() {
+        return eventBundler.bundleMessage("Closing channel");
+    }
+
+}

--- a/src/main/java/com/clueride/sse/game/GameStateService.java
+++ b/src/main/java/com/clueride/sse/game/GameStateService.java
@@ -15,7 +15,9 @@
  *
  * Created by jett on 3/6/18.
  */
-package com.clueride.sse;
+package com.clueride.sse.game;
+
+import com.clueride.sse.common.ServerSentEventChannel;
 
 /**
  * Defines operations on the Game State publish/subscribe service.

--- a/src/main/java/com/clueride/sse/game/GameStateServiceImpl.java
+++ b/src/main/java/com/clueride/sse/game/GameStateServiceImpl.java
@@ -15,7 +15,7 @@
  *
  * Created by jett on 3/6/18.
  */
-package com.clueride.sse;
+package com.clueride.sse.game;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,19 +23,21 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.sse.SseBroadcaster;
 
+import com.clueride.sse.common.KeepAliveGenerator;
+import com.clueride.sse.common.ServerSentEventChannel;
+
 /**
  * Implementation of GameStateService.
  */
 public class GameStateServiceImpl implements GameStateService {
     private static final Logger LOGGER = Logger.getLogger(GameStateServiceImpl.class);
 
-    private Map<Integer,ServerSentEventChannel> channelMap = new HashMap<>();
+    private Map<Integer, ServerSentEventChannel> channelMap = new HashMap<>();
     private final GameStateEventFactory gameStateEventFactory = new GameStateEventFactory();
 
     @Override
     public ServerSentEventChannel openChannelResources(Integer outingId) {
-        ServerSentEventChannel channel = getEventChannel(outingId);
-        return channel;
+        return getEventChannel(outingId);
     }
 
     @Override
@@ -56,7 +58,7 @@ public class GameStateServiceImpl implements GameStateService {
         keepAliveGenerator.reset();
     }
 
-    ServerSentEventChannel getEventChannel(Integer outingId) {
+    private ServerSentEventChannel getEventChannel(Integer outingId) {
         ServerSentEventChannel channel;
         if (channelMap.containsKey(outingId)) {
             channel = channelMap.get(outingId);

--- a/src/main/java/com/clueride/sse/game/GameStateWebService.java
+++ b/src/main/java/com/clueride/sse/game/GameStateWebService.java
@@ -4,23 +4,18 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
-   @PathParam("outingId") Integer outingId
-    ) {
-        gameStateService.releaseChannelResources(outingId);
-        return outingId;
-    }
-*
-        * http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
-            *
-            * Created by jett on 2/25/18.
-            */
-            package com.clueride.sse;
+ *
+ * Created by jett on 2/25/18.
+ */
+package com.clueride.sse.game;
 
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
@@ -36,6 +31,8 @@ import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.sse.EventOutput;
 import org.glassfish.jersey.media.sse.SseBroadcaster;
 import org.glassfish.jersey.media.sse.SseFeature;
+
+import com.clueride.sse.common.ServerSentEventChannel;
 
 /**
  * Broadcasts posted Game State changes to each of the clients who have subscribed to the events for a given Outing ID.

--- a/src/main/java/com/clueride/sse/game/README.md
+++ b/src/main/java/com/clueride/sse/game/README.md
@@ -1,0 +1,11 @@
+The endpoint defined within this package listens for connection
+requests on the `game-state-broadcast` channel. 
+
+This channel produces `SseFeature.SERVER_SENT_EVENTS` to 
+establish an open session with its subscribers.
+
+* Simple `GET` passing the outing ID subscribes to this channel.
+* A `POST` is used to send a string message (usually JSON) to
+listeners for a given outing ID.
+* A `POST` to the `close` path with the outing ID notifies
+subscribers that the channel is closing.

--- a/src/main/java/com/clueride/sse/heartbeat/HeartbeatEventFactory.java
+++ b/src/main/java/com/clueride/sse/heartbeat/HeartbeatEventFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.heartbeat;
+
+import java.lang.invoke.MethodHandles;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.log4j.Logger;
+import org.glassfish.jersey.media.sse.OutboundEvent;
+
+import com.clueride.sse.common.EventBundler;
+
+/**
+ * Creates the different events for Heartbeat, tethered or without
+ * the tether.
+ */
+public class HeartbeatEventFactory {
+    private static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    EventBundler eventBundler = new EventBundler();
+
+    OutboundEvent getHeartbeatEvent() {
+        return eventBundler.bundleMessage("Heartbeat");
+    }
+
+    public OutboundEvent getTetherEvent(LatLon latLon) {
+        String payload = "";
+        try {
+            payload = new ObjectMapper().writeValueAsString(latLon);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Unable to marshall this: " + latLon);
+            e.printStackTrace();
+        }
+        return eventBundler.bundleMessage(payload);
+    }
+
+}

--- a/src/main/java/com/clueride/sse/heartbeat/HeartbeatService.java
+++ b/src/main/java/com/clueride/sse/heartbeat/HeartbeatService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.heartbeat;
+
+import com.clueride.sse.common.ServerSentEventChannel;
+
+/**
+ * Defines operations on the Heartbeat publish/subscribe service.
+ */
+public interface HeartbeatService {
+
+    /**
+     * Channels are optionally opened against an Outing.
+     * @param outingId when provides, allows returning the tethered
+     *                 position data for the outing.
+     * @return Channel holding the EventOutput events, with or without tether data.
+     */
+    ServerSentEventChannel openChannelResources(Integer outingId);
+
+    /**
+     * When no more broadcast messages will be sent, this releases the resources.
+     *
+     * Note that the client Web Service is expected to send out close messages to
+     * the subscribers. This only shuts down the resources.
+     * @param outingId Unique identifier for the associated Outing.
+     */
+    void releaseChannelResources(Integer outingId);
+
+    /**
+     * For subscribers to an Outing, send this tether position.
+     * @param outingId unique identifier for the Outing.
+     * @param latLon new value for tether position to broadcast.
+     */
+    void broadcastTetherPosition(Integer outingId, LatLon latLon);
+
+}

--- a/src/main/java/com/clueride/sse/heartbeat/HeartbeatServiceImpl.java
+++ b/src/main/java/com/clueride/sse/heartbeat/HeartbeatServiceImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.heartbeat;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
+import com.clueride.sse.common.ServerSentEventChannel;
+import static java.lang.Thread.*;
+
+/**
+ * Implementation of HeartbeatService.
+ */
+public class HeartbeatServiceImpl implements HeartbeatService {
+    private static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Integer BROADCAST_ALL = -1;
+    private static Thread heartbeatRunnable = initHeartbeatThread();
+
+    private static Map<Integer, ServerSentEventChannel> channelMap = new HashMap<>();
+
+    private static final HeartbeatEventFactory heartbeatEventFactory = new HeartbeatEventFactory();
+
+    @Override
+    public ServerSentEventChannel openChannelResources(Integer outingId) {
+        return getEventChannel(outingId);
+    }
+
+    private static Thread initHeartbeatThread() {
+        Thread thread = new Thread(
+            new Runnable() {
+                @Override
+                public void run() {
+                    while (true) {
+                        for (ServerSentEventChannel channel : channelMap.values()) {
+                            LOGGER.debug("Sending Heartbeat to Outing " + channel.getOutingId());
+                            channel.getBroadcaster().broadcast(
+                                    heartbeatEventFactory.getHeartbeatEvent()
+                            );
+                        }
+                        try {
+                            sleep(10000);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+        );
+        thread.start();
+        return thread;
+    }
+
+    @Override
+    public void releaseChannelResources(Integer outingId) {
+        try {
+            heartbeatRunnable.join();
+        } catch (InterruptedException e) {
+            // Eat the exception when we bring this down intentionally
+        }
+    }
+
+    @Override
+    public void broadcastTetherPosition(Integer outingId, LatLon latLon) {
+
+    }
+
+    private ServerSentEventChannel getEventChannel(Integer outingId) {
+        ServerSentEventChannel channel;
+        /* Lazy init of the BROADCAST_ALL channel. */
+        if (outingId == null) {
+            outingId = BROADCAST_ALL;
+        }
+
+        if (channelMap.containsKey(outingId)) {
+            channel = channelMap.get(outingId);
+        } else {
+            channel = new ServerSentEventChannel(
+                    outingId
+            );
+            channelMap.put(outingId, channel);
+        }
+        return channel;
+    }
+
+}

--- a/src/main/java/com/clueride/sse/heartbeat/HeartbeatWebService.java
+++ b/src/main/java/com/clueride/sse/heartbeat/HeartbeatWebService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.heartbeat;
+
+import java.lang.invoke.MethodHandles;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import org.apache.log4j.Logger;
+import org.glassfish.jersey.media.sse.EventOutput;
+import org.glassfish.jersey.media.sse.SseBroadcaster;
+import org.glassfish.jersey.media.sse.SseFeature;
+
+import com.clueride.sse.common.ServerSentEventChannel;
+
+/**
+ * Broadcasts a Heartbeat to subscribers to verify a connection
+ * with the server is still alive.
+ *
+ * For subscribers providing an Outing ID, the heartbeat message will
+ * include tethered position for that Outing.
+ */
+@Singleton
+@Path("heartbeat")
+public class HeartbeatWebService {
+    private static Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private HeartbeatService heartbeatService = new HeartbeatServiceImpl();
+
+    @GET
+    @Produces(SseFeature.SERVER_SENT_EVENTS)
+    public EventOutput subscribeToHeartbeat(
+            @QueryParam("r") final String requestId
+    ) {
+        LOGGER.debug("Heartbeat subscribe - requestId: " + requestId);
+        ServerSentEventChannel channel = heartbeatService.openChannelResources(null);
+        SseBroadcaster broadcaster = channel.getBroadcaster();
+        EventOutput eventOutput = new EventOutput();
+        broadcaster.add(eventOutput);
+        return eventOutput;
+    }
+
+}

--- a/src/main/java/com/clueride/sse/heartbeat/LatLon.java
+++ b/src/main/java/com/clueride/sse/heartbeat/LatLon.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/24/19.
+ */
+package com.clueride.sse.heartbeat;
+
+/**
+ * Holds latitude and longitude.
+ *
+ * Main purpose is to marshall JSON via Jersey.
+ */
+public class LatLon {
+    double lat;
+    double lon;
+}

--- a/src/main/java/com/clueride/sse/heartbeat/README.md
+++ b/src/main/java/com/clueride/sse/heartbeat/README.md
@@ -1,0 +1,14 @@
+The endpoint defined within this package listens for connection
+requests on the `heartbeat` channel. 
+
+This channel produces `SseFeature.SERVER_SENT_EVENTS` to 
+establish an open session with its subscribers.
+
+* Simple `GET` without an Outing ID subscribes to this channel.
+Providing an Outing ID will include tethered position data for
+that outing in the heartbeat messages. Heartbeats are provided
+on an interval if no other message has been sent on the channel.
+* A `POST` to the `tether` path is used to send coordinates to
+listeners for a given outing ID.
+* A `POST` to the `close` path with the outing ID notifies
+subscribers that the channel is closing.

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -3,3 +3,6 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 # log4j.appender.stdout.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.appender.stdout.layout.ConversionPattern=%d [%c] %-5p - %m%n
+
+log4j.logger.com.clueride.sse.CORSFilter=INFO
+log4j.logger.com.clueride.sse.heartbeat=INFO

--- a/src/test/java/com/clueride/sse/KeepAliveGeneratorTest.java
+++ b/src/test/java/com/clueride/sse/KeepAliveGeneratorTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.clueride.sse.common.KeepAliveGenerator;
 import static org.testng.Assert.*;
 
 /**


### PR DESCRIPTION
- Adds full set of Heartbeat Endpoint and Service including a thread
that generates "Heartbeat" messages on a 10-second interval.

NOTE: This is distinct from the internal KeepAlive that is used
underneath the covers to keep the connection open.

- Refactors shared code between Game State and Heartbeat into 'common'
package.
- Prepares (but not completes) work for adding a tether message. This
does take into account the presence or absence of an Outing ID -- no
tether unless you're part of an Outing whose Guide you can tether to.