### PR TITLE
SSE-17 Open SSE channel against specific Users - Web Service first

### DIFF
--- a/src/main/java/com/clueride/sse/common/CommonChannelService.java
+++ b/src/main/java/com/clueride/sse/common/CommonChannelService.java
@@ -19,19 +19,10 @@ package com.clueride.sse.common;
 
 import java.util.Map;
 
-import org.glassfish.jersey.media.sse.EventOutput;
-
 /**
  * Defines common operations on Channels.
  */
 public interface CommonChannelService {
-    /**
-     * Open a generic channel that is non-specific to an outing.
-     *
-     * @return instance of {@link ServerSentEventChannel} for communication without
-     * knowledge of a specific Outing.
-     */
-    ServerSentEventChannel openChannelResources();
 
     /**
      * Retrieve a previously opened Event Channel for the given Outing and Puzzle.
@@ -40,29 +31,27 @@ public interface CommonChannelService {
      * @return instance of {@link ServerSentEventChannel} for events specific
      * to the Outing and the Puzzle.
      */
-    ServerSentEventChannel getEventChannel(Integer outingId);
+    ServerSentEventChannel getOutingChannel(Integer outingId);
+
+    /**
+     * Retrieve a previously opened Event Channel for the given User.
+     *
+     * @param badgeOsId unique identifier for a potential badge recipient.
+     * @return Channel for broadcasting to a specific user.
+     */
+    ServerSentEventChannel getUserChannel(Integer badgeOsId);
 
     /**
      * Returns the map of Channels per Outing ID.
      * @return Map of ServerSentEventChannel per Integer outingId.
      */
-    Map<Integer, CommonChannel> getChannelMap();
+    Map<Integer, CommonChannel> getOutingChannelMap();
+
 
     /**
-     * Given an Outing ID, return an instance of EventOutput which holds and open
-     * session against the Outing's channel.
-     *
-     * @param outingId unique identifier for the Outing and its corresponding Channel.
-     * @return instance of EventOutput suitable for returning to the client to hold session open.
+     * Returns the map of Channels per User ID.
+     * @return Map of ServerSentEventChannel per Integer badgeOsId.
      */
-    EventOutput getEventOutputForOuting(Integer outingId);
-
-    /**
-     * Return an instance of what?
-     *
-     * TODO: SSE-17 Turn this into the one that listens for Badges against a User ID.
-     * @return crap.
-     */
-    EventOutput getGenericEventOutput();
+    Map<Integer, CommonChannel> getUserChannelMap();
 
 }

--- a/src/main/java/com/clueride/sse/event/answer/AnswerSummaryServiceImpl.java
+++ b/src/main/java/com/clueride/sse/event/answer/AnswerSummaryServiceImpl.java
@@ -49,7 +49,7 @@ public class AnswerSummaryServiceImpl implements AnswerSummaryService {
                 )
         );
 
-        ServerSentEventChannel channel = commonChannelService.getEventChannel(
+        ServerSentEventChannel channel = commonChannelService.getOutingChannel(
                 outingId
         );
 

--- a/src/main/java/com/clueride/sse/event/badge/BadgeAwardServiceImpl.java
+++ b/src/main/java/com/clueride/sse/event/badge/BadgeAwardServiceImpl.java
@@ -49,7 +49,7 @@ public class BadgeAwardServiceImpl implements BadgeAwardService {
                 )
         );
 
-        ServerSentEventChannel channel = commonChannelService.getEventChannel(
+        ServerSentEventChannel channel = commonChannelService.getOutingChannel(
                 outingId
         );
 

--- a/src/main/java/com/clueride/sse/event/game/GameStateServiceImpl.java
+++ b/src/main/java/com/clueride/sse/event/game/GameStateServiceImpl.java
@@ -44,7 +44,7 @@ public class GameStateServiceImpl implements GameStateService {
                         gameStateEventAsJSON
                 )
         );
-        ServerSentEventChannel channel = commonChannelService.getEventChannel(outingId);
+        ServerSentEventChannel channel = commonChannelService.getOutingChannel(outingId);
         SseBroadcaster broadcaster = channel.getBroadcaster();
         broadcaster.broadcast(eventBundler.bundleMessage(gameStateEventAsJSON, EventType.GAME_STATE));
         channel.getKeepAliveGenerator().reset();

--- a/src/main/java/com/clueride/sse/eventoutput/EventOutputService.java
+++ b/src/main/java/com/clueride/sse/eventoutput/EventOutputService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/25/20.
+ */
+package com.clueride.sse.eventoutput;
+
+import org.glassfish.jersey.media.sse.EventOutput;
+
+/**
+ * Produces and maintains EventOutput instances appropriate
+ * for the requests to open an SSE Channel.
+ */
+public interface EventOutputService {
+
+    /**
+     * Assigns an EventOutput that broadcasts events that are not specific
+     * to a given outing (Badges and Open/Close).
+     *
+     * @param badgeOsId Unique identifier for the user's Badge Account.
+     * @return EventOutput object that holds open the session and broadcasts appropriate events.
+     */
+    EventOutput getEventOutputForUser(Integer badgeOsId);
+
+    /**
+     * Given an Outing ID, return an instance of EventOutput which holds and open
+     * session against the Outing's channel.
+     *
+     * Includes the events that are specific to a given user as well.
+     *
+     * @param badgeOsId Unique identifier for the user's Badge Account.
+     * @param outingId unique identifier for the Outing and its corresponding Channel.
+     * @return instance of EventOutput suitable for returning to the client to hold session open.
+     */
+    EventOutput getEventOutputForOuting(Integer badgeOsId, Integer outingId);
+
+}

--- a/src/main/java/com/clueride/sse/eventoutput/EventOutputServiceImpl.java
+++ b/src/main/java/com/clueride/sse/eventoutput/EventOutputServiceImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/25/20.
+ */
+package com.clueride.sse.eventoutput;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.glassfish.jersey.media.sse.EventOutput;
+import org.glassfish.jersey.media.sse.SseBroadcaster;
+
+import com.clueride.sse.common.CommonChannelService;
+import com.clueride.sse.common.CommonChannelServiceImpl;
+import com.clueride.sse.common.ServerSentEventChannel;
+
+/**
+ * Default implementation of {@link EventOutputService}.
+ */
+public class EventOutputServiceImpl implements EventOutputService {
+
+    private CommonChannelService channelService = new CommonChannelServiceImpl();
+
+    private static Map<Integer, EventOutput> eventOutputPerUser = new HashMap<>();
+
+    @Override
+    public EventOutput getEventOutputForUser(Integer badgeOsId) {
+        EventOutput eventOutput = eventOutputPerUser.get(badgeOsId);
+        if (eventOutput == null) {
+            eventOutput = new EventOutput();
+            eventOutputPerUser.put(badgeOsId, eventOutput);
+        }
+
+        ServerSentEventChannel userChannel = channelService.getUserChannel(badgeOsId);
+        SseBroadcaster userBroadcaster = userChannel.getBroadcaster();
+        userBroadcaster.add(eventOutput);
+
+        return eventOutput;
+    }
+
+    @Override
+    public EventOutput getEventOutputForOuting(Integer badgeOsId, Integer outingId) {
+        EventOutput eventOutput = getEventOutputForUser(badgeOsId);
+
+        ServerSentEventChannel outingChannel = channelService.getOutingChannel(outingId);
+        SseBroadcaster outingBroadcaster = outingChannel.getBroadcaster();
+        outingBroadcaster.add(eventOutput);
+
+        return eventOutput;
+    }
+
+}


### PR DESCRIPTION
- Changes the endpoints for SSE to accept BadgeOS ID.
- Adds map for a channel/EventOutput per User along with the Outing Channel.
- Factors out the EventOutput service.

Operational, but needs the attention of SSE-19 to make sure we're using
the right channels for broadcasting stuff and that the KeepAlive does
what we want.