### PR TITLE
SSE-22 DIY Channel Management

### DIFF
--- a/src/main/java/com/clueride/sse/channel/ChannelWebService.java
+++ b/src/main/java/com/clueride/sse/channel/ChannelWebService.java
@@ -61,7 +61,7 @@ public class ChannelWebService {
             @PathParam("badgeOsId") Integer badgeOsId,
             @QueryParam("r") final String requestId
     ) {
-        LOGGER.debug("Generic SSE Channel request: " + requestId + " for " + badgeOsId);
+        LOGGER.debug("User-only SSE Channel request: " + requestId + " for " + badgeOsId);
         return eventOutputService.getEventOutputForUser(badgeOsId, requestId);
     }
 
@@ -82,9 +82,9 @@ public class ChannelWebService {
             @QueryParam("r") final String requestId
     ) {
         LOGGER.debug(
-                "BadgeOS ID " + badgeOsId +
-                " Outing ID " + outingId +
-                " SSE Channel request " + requestId
+                "Outing-based SSE Channel request " + requestId +
+                " for " + badgeOsId +
+                " on Outing ID " + outingId
         );
         return eventOutputService.getEventOutputForOuting(
                 badgeOsId,


### PR DESCRIPTION
- Changes algorithm for removals: deletes everything and re-adds what
we want to keep. Unfortunately, there would be requests to close resources
for abandoned connections and these would clear out the good ones, so
that led to ...
- Adds removal of old resources for a user when a new request comes in.
- Makes the logging more consistent.